### PR TITLE
Exit with 0 on success, per UNIX convention

### DIFF
--- a/src/asm.c
+++ b/src/asm.c
@@ -78,7 +78,11 @@ int main(int argc, char *argv[]) {
 	}
 	fclose(file_tmp); /* close temporary file */
 	remove(tmpdev);   /* delete temporary file */
-	return (1);       /* close files, release memory, exit */
+
+	/* Originally 'main()' returned (1), which by VMS convention is a success
+	   code. Changed to (0) to match the UNIX convention. */
+	
+	return (0);       /* close files, release memory, exit */
 }
 
 void open_files(int argc, char *argv[]) { /* open files and initialize things */


### PR DESCRIPTION
This makes it a bit easier to integrate cbm6502asm into Makefiles and build scripts.

Presumably the original exit code of (1) was due to the VMS convention that odd numbers indicate success and even numbers indicate failure.

Scanning the source code, the other error codes returned by other exit paths look to already be compatible with UNIX:
* Displaying help (/?), which exists with 0.
* error_msg(), which exits with a positive error code when fatal >= 2.
